### PR TITLE
Update callbacks for Rails 5

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -502,7 +502,7 @@ module Paperclip
 
       instance.run_paperclip_callbacks(:post_process) do
         instance.run_paperclip_callbacks(:"#{name}_post_process") do
-          unless @options[:check_validity_before_processing] && instance.errors.any?
+          if !@options[:check_validity_before_processing] || !instance.errors.any?
             post_process_styles(*style_args)
           end
         end

--- a/lib/paperclip/callbacks.rb
+++ b/lib/paperclip/callbacks.rb
@@ -23,10 +23,12 @@ module Paperclip
       private
 
       def callback_terminator
-        if ::ActiveSupport::VERSION::STRING >= '4.1'
-          lambda { |target, result| result == false }
-        else
-          'result == false'
+        lambda do |_, result|
+          if result.respond_to?(:call)
+            result.call == false
+          else
+            result == false
+          end
         end
       end
     end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/commit/2386daabe7f8c979b453010dc0de3e1f6bbf859d

Specifically:

> Chains of callbacks defined **with** a `:terminator` option will
> maintain their existing behavior of halting as soon as a `before_`
> callback matches the terminator's expectation. For instance,
> ActiveModel's callbacks will still halt the chain when a `before_`
> callback returns `false`.

In terminator callbacks, the `result` value changed to be a lambda now. This change reflects that, updating the terminator to compare the result of the block to `false`.

Also:

* Removes Rails 4.1 branch (we don't support it anymore)
* Rewrite for legibility: change `unless` for `if`